### PR TITLE
ColumnType, null handling in sqliteutil.exec. Closes #11

### DIFF
--- a/sqlite.go
+++ b/sqlite.go
@@ -712,6 +712,57 @@ func (stmt *Stmt) columnBytes(col int) []byte {
 	return (*[1 << 28]byte)(unsafe.Pointer(p))[:n:n]
 }
 
+// ColumnType are codes for each of the SQLite fundamental datatypes:
+//
+//   64-bit signed integer
+//   64-bit IEEE floating point number
+//   string
+//   BLOB
+//   NULL
+//
+// https://www.sqlite.org/c3ref/c_blob.html
+type ColumnType int
+
+const (
+	SQLITE_INTEGER = ColumnType(C.SQLITE_INTEGER)
+	SQLITE_FLOAT   = ColumnType(C.SQLITE_FLOAT)
+	SQLITE_TEXT    = ColumnType(C.SQLITE3_TEXT)
+	SQLITE_BLOB    = ColumnType(C.SQLITE_BLOB)
+	SQLITE_NULL    = ColumnType(C.SQLITE_NULL)
+)
+
+func (t ColumnType) String() string {
+	switch t {
+	case SQLITE_INTEGER:
+		return "SQLITE_INTEGER"
+	case SQLITE_FLOAT:
+		return "SQLITE_FLOAT"
+	case SQLITE_TEXT:
+		return "SQLITE_TEXT"
+	case SQLITE_BLOB:
+		return "SQLITE_BLOB"
+	case SQLITE_NULL:
+		return "SQLITE_NULL"
+	default:
+		return "<unknown sqlite datatype>"
+	}
+}
+
+// ColumnType returns the datatype code for the initial data
+// type of the result column. The returned value is one of:
+//
+//   SQLITE_INTEGER
+//   SQLITE_FLOAT
+//   SQLITE_TEXT
+//   SQLITE_BLOB
+//   SQLITE_NULL
+//
+// Column indicies start at 0.
+// https://www.sqlite.org/c3ref/column_blob.html
+func (stmt *Stmt) ColumnType(col int) ColumnType {
+	return ColumnType(C.sqlite3_column_type(stmt.stmt, C.int(col)))
+}
+
 // ColumnText returns a query result as a string.
 //
 // Column indicies start at 0.

--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -96,6 +96,14 @@ func TestConn(t *testing.T) {
 		if getIntVal := stmt.GetInt64("foo2"); getIntVal != intVal {
 			t.Errorf(`GetText("foo2")=%q, want %q`, getIntVal, intVal)
 		}
+		typ := stmt.ColumnType(0)
+		if typ != sqlite.SQLITE_TEXT {
+			t.Errorf(`ColumnType(0)=%q, want %q`, typ, sqlite.SQLITE_TEXT)
+		}
+		intTyp := stmt.ColumnType(1)
+		if intTyp != sqlite.SQLITE_INTEGER {
+			t.Errorf(`ColumnType(1)=%q, want %q`, intTyp, sqlite.SQLITE_INTEGER)
+		}
 		gotVals = append(gotVals, val)
 		gotInts = append(gotInts, intVal)
 	}

--- a/sqliteutil/exec.go
+++ b/sqliteutil/exec.go
@@ -115,6 +115,8 @@ func exec(stmt *sqlite.Stmt, resultFn func(stmt *sqlite.Stmt) error, args []inte
 			stmt.BindFloat(i, v.Float())
 		case reflect.String:
 			stmt.BindText(i, v.String())
+		case reflect.Invalid:
+			stmt.BindNull(i)
 		default:
 			if v.Kind() == reflect.Slice && v.Type().Elem().Kind() == reflect.Uint8 {
 				stmt.BindBytes(i, v.Bytes())


### PR DESCRIPTION
I went ahead and added what I need to resolve https://github.com/crawshaw/sqlite/issues/11

This:

  * Adds `stmt.ColumnType()` which returns...
  * `ColumnType`, an alias of `int`, mapped to sqlite's 5 datatype codes...
  * with a `String()` function for printing
  * This also lets one bind null by passing `nil` in the `args []interface{}` of `sqliteutil.Exec{,Raw}`

I added minimal testing, as the existing tests were pretty minimal - didn't want to blow up the PR's size!

(Also TIL `reflect.ValueOf(nil).Kind() == reflect.Invalid`. nil is weird)