### PR TITLE
pool: fix segfault of Get after Close

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -78,7 +78,10 @@ func Open(uri string, flags OpenFlags, poolSize int) (*Pool, error) {
 // details.
 func (p *Pool) Get(doneCh <-chan struct{}) *Conn {
 	select {
-	case conn := <-p.free:
+	case conn, ok := <-p.free:
+		if !ok {
+			return nil // pool is closed
+		}
 		conn.SetInterrupt(doneCh)
 		return conn
 	case <-doneCh:


### PR DESCRIPTION
- p.Get(doneCh) waits on p.free, doneCh and p.closed .
- p.Close() closes both p.free and p.closed .

Because select selects ready case randomly on a closed pool Get randomly
selects either p.free or p.closed, and if p.free is selected, it segfaults in
conn.SetInterrupt() because conn is nil:

	--- FAIL: TestPoolAfterClose (0.00s)
	panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	        panic: runtime error: invalid memory address or nil pointer dereference
	[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x504966]

	goroutine 66 [running]:
	testing.tRunner.func1(0xc4201d2000)
	        /home/kirr/src/tools/go/go/src/testing/testing.go:742 +0x29d
	panic(0x5e8080, 0x8eac70)
	        /home/kirr/src/tools/go/go/src/runtime/panic.go:502 +0x229
	crawshaw.io/sqlite.(*Conn).SetInterrupt(0x0, 0x0)
	        /home/kirr/src/neo/src/crawshaw.io/sqlite/sqlite.go:189 +0x26
	crawshaw.io/sqlite.(*Pool).Get(0xc4200ce5a0, 0x0, 0x0)
	        /home/kirr/src/neo/src/crawshaw.io/sqlite/pool.go:82 +0x182
	crawshaw.io/sqlite_test.TestPoolAfterClose(0xc4201d2000)
	        /home/kirr/src/neo/src/crawshaw.io/sqlite/pool_test.go:121 +0xc6
	testing.tRunner(0xc4201d2000, 0x61b9d0)
	        /home/kirr/src/tools/go/go/src/testing/testing.go:777 +0xd0
	created by testing.(*T).Run
	        /home/kirr/src/tools/go/go/src/testing/testing.go:824 +0x2e0
	exit status 2
	FAIL    crawshaw.io/sqlite      0.113s

Fix it by checking in p.free ready case whether we indeed receive live Conn or
whether it is due to pool Close.