### PR TITLE
Add simple travis config, closes #22

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: "go"
+
+go:
+  - "1.9.x"
+  - "1.10.x"
+
+os:
+  - "linux"
+  - "osx"
+
+go_import_path: crawshaw.io/sqlite

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Go interface to SQLite.
 
+[![Build Status](https://travis-ci.org/crawshaw/sqlite.svg?branch=master)](https://travis-ci.org/crawshaw/sqlite)
+
 This is not a database/sql driver.
 
 ```go get -u crawshaw.io/sqlite```


### PR DESCRIPTION
Just what it says on the tin.

This runs tests on Windows & macOS, on the latest 1.9.x and 1.10.x releases