### PR TITLE
Allow arg of type 'bool' in sqliteutil.exec()

### DIFF
--- a/sqliteutil/exec.go
+++ b/sqliteutil/exec.go
@@ -38,6 +38,7 @@ import (
 //	floats   to BindFloat
 //	[]byte   to BindBytes
 //	string   to BindText
+//	bool     to BindBool
 //
 // All other kinds are printed using fmt.Sprintf("%v", v) and passed
 // to BindText.
@@ -120,6 +121,8 @@ func exec(stmt *sqlite.Stmt, resultFn func(stmt *sqlite.Stmt) error, args []inte
 			stmt.BindFloat(i, v.Float())
 		case reflect.String:
 			stmt.BindText(i, v.String())
+		case reflect.Bool:
+			stmt.BindBool(i, v.Bool())
 		case reflect.Invalid:
 			stmt.BindNull(i)
 		default:


### PR DESCRIPTION
I'm going through [my sqliteutil fork](https://github.com/itchio/hades/tree/master/sqliteutil2) to see what else could be generally useful, I think that's one of these.