### PR TITLE
README.md: add GoDoc badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Go interface to SQLite.
 
-[![Build Status](https://travis-ci.org/crawshaw/sqlite.svg?branch=master)](https://travis-ci.org/crawshaw/sqlite) (linux and macOS) [![Build status](https://ci.appveyor.com/api/projects/status/jh9xx6cut73ufkl8?svg=true)](https://ci.appveyor.com/project/crawshaw/sqlite) (windows)
+[![GoDoc](https://godoc.org/crawshaw.io/sqlite?status.svg)](https://godoc.org/crawshaw.io/sqlite) [![Build Status](https://travis-ci.org/crawshaw/sqlite.svg?branch=master)](https://travis-ci.org/crawshaw/sqlite) (linux and macOS) [![Build status](https://ci.appveyor.com/api/projects/status/jh9xx6cut73ufkl8?svg=true)](https://ci.appveyor.com/project/crawshaw/sqlite) (windows)
 
 This package provides a low-level Go interface to SQLite 3 designed to take maximum advantage of multi-threading. Connections are [pooled](https://godoc.org/crawshaw.io/sqlite#Pool) and take advantage of the SQLite [shared cache](https://www.sqlite.org/sharedcache.html) mode and the package takes advantage of the [unlock-notify API](https://www.sqlite.org/unlock_notify.html) to minimize the amount of handling user code needs for dealing with database lock contention.
 


### PR DESCRIPTION
One of the first things I look for on a Go package's README is a link to godoc.org.  I notice you do have one at the bottom of the README, but I also think the badge is a nice and clear way of linking to package documentation near the top of the README as well.

I didn't add it in this PR because it's a bit more subjective, but Go Report Card is another good one to consider: https://goreportcard.com/report/crawshaw.io/sqlite.  If you'd like, I can add that as well.

Thanks for this package!