### PR TITLE
Fix typo in example code (handle -> handler)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ func main() {
 	log.Fatal(http.ListenAndServe(":8080", nil))
 }
 
-func handle(w http.ResponseWriter, r *http.Request) {
+func handler(w http.ResponseWriter, r *http.Request) {
 	conn := dbpool.Get(r.Context().Done())
 	if conn == nil {
 		return


### PR DESCRIPTION
The `main()` function in the README's example code refers to a `handler` callback, but `func handle` (without the "r") is defined later in the code.

This fix changes the defined function name to `handler` to match the callback in `main()`, making the example more clear.