### PR TITLE
Fix sqlitex_pool bit not being passed (and a deadlock)

### DIFF
--- a/sqlitex/pool.go
+++ b/sqlitex/pool.go
@@ -80,7 +80,7 @@ func Open(uri string, flags sqlite.OpenFlags, poolSize int) (*Pool, error) {
 
 	// sqlitex_pool is also defined in package sqlite
 	const sqlitex_pool = sqlite.OpenFlags(0x01000000)
-	flags &= sqlitex_pool
+	flags |= sqlitex_pool
 
 	p.allMu.Lock()
 	defer p.allMu.Unlock()


### PR DESCRIPTION
Attempt to fix a bug in sqlitex pools where flags aren't being
propagated to OpenConn calls correctly. Flags ends up being
bitwise-and-ed to zero unless the caller of sqlitex.Open explicitly
adds this to the flags (and even then, it ends up being the only bit
set). With this, zero is always passed to sqlite.OpenConn, which
produces desirable default flags for a file-based pool, but invalid
flags for a memory-based pool with a size over 1.

This is related to but does not fix #43 (since this only visibly
affected memory pools for me). That's a matter of using appropriate
defaults for in-memory databases. It does make it possible to work
around it by passing the SQLITE_OPEN_SHAREDCACHE flag to sqlitex.Open,
so it's a start.

There's a second commit in this PR because I stumbled onto another
bug in the process. I won't copy/paste its message into the PR description,
but it's something to be aware of.