### PR TITLE
Fix _db_config args to avoid LoadExtension panic

### DIFF
--- a/extension.go
+++ b/extension.go
@@ -19,7 +19,7 @@ import "unsafe"
 // #include <stdlib.h>
 // #include <sqlite3.h>
 // static int db_config_onoff(sqlite3* db, int op, int onoff) {
-//   return sqlite3_db_config(db, op, onoff);
+//   return sqlite3_db_config(db, op, onoff, NULL);
 // }
 import "C"
 


### PR DESCRIPTION
LoadExtension would panic because sqlite3_db_config expects two
additional args when called with op
SQLITE_DBCONFIG_ENABLE_LOAD_EXTENSION. The second argument is a pointer
to the set value which can be used as an additional check. This is not
used but the NULL pointer arg must still be supplied to avoid a seg
fault.

https://www.sqlite.org/c3ref/c_dbconfig_defensive.html#sqlitedbconfigenableloadextension

Fix #62