### PR TITLE
Add Type(), IsNil(), & Blob() to type Value

### DIFF
--- a/func.go
+++ b/func.go
@@ -69,16 +69,19 @@ type Value struct {
 	ptr *C.sqlite3_value
 }
 
-func (v Value) Int() int       { return int(C.sqlite3_value_int(v.ptr)) }
-func (v Value) Int64() int64   { return int64(C.sqlite3_value_int64(v.ptr)) }
-func (v Value) Float() float64 { return float64(C.sqlite3_value_double(v.ptr)) }
-func (v Value) Len() int       { return int(C.sqlite3_value_bytes(v.ptr)) }
+func (v Value) IsNil() bool      { return v.ptr == nil }
+func (v Value) Int() int         { return int(C.sqlite3_value_int(v.ptr)) }
+func (v Value) Int64() int64     { return int64(C.sqlite3_value_int64(v.ptr)) }
+func (v Value) Float() float64   { return float64(C.sqlite3_value_double(v.ptr)) }
+func (v Value) Len() int         { return int(C.sqlite3_value_bytes(v.ptr)) }
+func (v Value) Type() ColumnType { return ColumnType(C.sqlite3_value_type(v.ptr)) }
 func (v Value) Text() string {
 	n := v.Len()
 	return C.GoStringN((*C.char)(unsafe.Pointer(C.sqlite3_value_text(v.ptr))), C.int(n))
 }
 func (v Value) Blob() []byte {
-	panic("TODO")
+	n := v.Len()
+	return C.GoBytes(unsafe.Pointer(C.sqlite3_value_blob(v.ptr)), C.int(n))
 }
 
 type xfunc struct {

--- a/func.go
+++ b/func.go
@@ -76,12 +76,14 @@ func (v Value) Float() float64   { return float64(C.sqlite3_value_double(v.ptr))
 func (v Value) Len() int         { return int(C.sqlite3_value_bytes(v.ptr)) }
 func (v Value) Type() ColumnType { return ColumnType(C.sqlite3_value_type(v.ptr)) }
 func (v Value) Text() string {
+	ptr := unsafe.Pointer(C.sqlite3_value_text(v.ptr))
 	n := v.Len()
-	return C.GoStringN((*C.char)(unsafe.Pointer(C.sqlite3_value_text(v.ptr))), C.int(n))
+	return C.GoStringN((*C.char)(ptr), C.int(n))
 }
 func (v Value) Blob() []byte {
+	ptr := unsafe.Pointer(C.sqlite3_value_blob(v.ptr))
 	n := v.Len()
-	return C.GoBytes(unsafe.Pointer(C.sqlite3_value_blob(v.ptr)), C.int(n))
+	return C.GoBytes(ptr, C.int(n))
 }
 
 type xfunc struct {


### PR DESCRIPTION
Previously it was impossible to access the sqlite3_value_type() function
for a Value. Now this is exposed via Value.Type().

Additionally, it was impossible to know if a returned Value was actually
nil, which can occur when ChangesetIter.New() has no change for the
given column. Using any of the returned Value's methods would result in
panic. Now this can be checked using Value.IsNil().

Also, Value.Blob() is now implemented.

Issue #61