### PR TITLE
readme: update the installation procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ A utility package, [sqlitex](https://godoc.org/crawshaw.io/sqlite/sqlitex), prov
 
 This is not a database/sql driver.
 
+## Installation
+
+If using _go modules_:
+
+```go get -u crawshaw.io/sqlite@master```
+
+otherwise:
+
 ```go get -u crawshaw.io/sqlite```
 
 ## Example


### PR DESCRIPTION
This is a small readme improvement for users of go modules. I just had the same problem as #58 and it was because go by default selects the v0.1.2 tag which doesn't have the fix mentioned.

By explicitly selecting the master branch it works.