### PR TITLE
sqlite: import upstream version v3.29.0

### DIFF
--- a/session_test.go
+++ b/session_test.go
@@ -24,10 +24,10 @@ import (
 )
 
 func initT(t *testing.T, conn *sqlite.Conn) {
-	if _, err := conn.Prep(`INSERT INTO t (c1, c2, c3) VALUES ("1", "2", "3");`).Step(); err != nil {
+	if _, err := conn.Prep(`INSERT INTO t (c1, c2, c3) VALUES ('1', '2', '3');`).Step(); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := conn.Prep(`INSERT INTO t (c1, c2, c3) VALUES ("4", "5", "6");`).Step(); err != nil {
+	if _, err := conn.Prep(`INSERT INTO t (c1, c2, c3) VALUES ('4', '5', '6');`).Step(); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -52,11 +52,11 @@ func fillSession(t *testing.T) (*sqlite.Conn, *sqlite.Session) {
 	}
 
 	stmts := []string{
-		`UPDATE t SET c1="one" WHERE c1="1";`,
-		`UPDATE t SET c2="two", c3="three" WHERE c1="one";`,
-		`UPDATE t SET c1="noop" WHERE c2="2";`,
-		`DELETE FROM t WHERE c1="4";`,
-		`INSERT INTO t (c1, c2, c3) VALUES ("four", "five", "six");`,
+		`UPDATE t SET c1='one' WHERE c1='1';`,
+		`UPDATE t SET c2='two', c3='three' WHERE c1='one';`,
+		`UPDATE t SET c1='noop' WHERE c2='2';`,
+		`DELETE FROM t WHERE c1='4';`,
+		`INSERT INTO t (c1, c2, c3) VALUES ('four', 'five', 'six');`,
 	}
 
 	for _, stmt := range stmts {

--- a/sqlite.go
+++ b/sqlite.go
@@ -27,6 +27,7 @@ package sqlite
 // #cgo CFLAGS: -DSQLITE_USE_ALLOCA
 // #cgo CFLAGS: -DSQLITE_ENABLE_COLUMN_METADATA
 // #cgo CFLAGS: -DHAVE_USLEEP=1
+// #cgo CFLAGS: -DSQLITE_DQS=0
 // #cgo windows LDFLAGS: -Wl,-Bstatic -lwinpthread -Wl,-Bdynamic
 // #cgo linux LDFLAGS: -ldl -lm
 // #cgo linux CFLAGS: -std=c99
@@ -49,6 +50,10 @@ package sqlite
 // extern void log_fn(void* pArg, int code, char* msg);
 // static void enable_logging() {
 //	sqlite3_config(SQLITE_CONFIG_LOG, log_fn, NULL);
+// }
+//
+// static int db_config_onoff(sqlite3* db, int op, int onoff) {
+//   return sqlite3_db_config(db, op, onoff, NULL);
 // }
 import "C"
 import (
@@ -194,8 +199,40 @@ func (conn *Conn) Close() error {
 	return reserr("Conn.Close", "", "", res)
 }
 
-// CheckResult reports whether any statement on this connection
-// is in the process of returning results.
+const (
+	SQLITE_DBCONFIG_DQS_DML = C.int(C.SQLITE_DBCONFIG_DQS_DML)
+	SQLITE_DBCONFIG_DQS_DDL = C.int(C.SQLITE_DBCONFIG_DQS_DDL)
+)
+
+// EnableDoubleQuotedStringLiterals allows fine grained control over whether
+// double quoted string literals are accepted in Data Manipulation Language or
+// Data Definition Language queries.
+//
+// By default DQS is disabled since double quotes should indicate an identifier.
+//
+// https://sqlite.org/quirks.html#dblquote
+func (conn *Conn) EnableDoubleQuotedStringLiterals(dml, ddl bool) error {
+	var enable C.int
+	if dml {
+		enable = 1
+	}
+	res := C.db_config_onoff(conn.conn, SQLITE_DBCONFIG_DQS_DML, enable)
+	if res != 0 {
+		return reserr("Conn.EnableDoubleQuotedStringLiterals", "", "", res)
+	}
+	enable = 0
+	if ddl {
+		enable = 1
+	}
+	res = C.db_config_onoff(conn.conn, SQLITE_DBCONFIG_DQS_DDL, enable)
+	if res != 0 {
+		return reserr("Conn.EnableDoubleQuotedStringLiterals", "", "", res)
+	}
+	return nil
+}
+
+// CheckReset reports whether any statement on this connection is in the process
+// of returning results.
 func (conn *Conn) CheckReset() string {
 	for _, stmt := range conn.stmts {
 		if stmt.lastHasRow {

--- a/sqlite3.h
+++ b/sqlite3.h
@@ -123,9 +123,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.28.0"
-#define SQLITE_VERSION_NUMBER 3028000
-#define SQLITE_SOURCE_ID      "2019-04-16 19:49:53 884b4b7e502b4e991677b53971277adfaf0a04a284f8e483e2553d0f83156b50"
+#define SQLITE_VERSION        "3.29.0"
+#define SQLITE_VERSION_NUMBER 3029000
+#define SQLITE_SOURCE_ID      "2019-07-10 17:32:03 fc82b73eaac8b36950e527f12c4b5dc1e147e6f4ad2217ae43ad82882a88bfa6"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers
@@ -1296,8 +1296,14 @@ typedef struct sqlite3_api_routines sqlite3_api_routines;
 ** ^The flags argument to xAccess() may be [SQLITE_ACCESS_EXISTS]
 ** to test for the existence of a file, or [SQLITE_ACCESS_READWRITE] to
 ** test whether a file is readable and writable, or [SQLITE_ACCESS_READ]
-** to test whether a file is at least readable.   The file can be a
-** directory.
+** to test whether a file is at least readable.  The SQLITE_ACCESS_READ
+** flag is never actually used and is not implemented in the built-in
+** VFSes of SQLite.  The file is named by the second argument and can be a
+** directory. The xAccess method returns [SQLITE_OK] on success or some
+** non-zero error code if there is an I/O error or if the name of
+** the file given in the second argument is illegal.  If SQLITE_OK
+** is returned, then non-zero or zero is written into *pResOut to indicate
+** whether or not the file is accessible.  
 **
 ** ^SQLite will always allocate at least mxPathname+1 bytes for the
 ** output buffer xFullPathname.  The exact size of the output buffer
@@ -2198,6 +2204,7 @@ struct sqlite3_mem_methods {
 ** features include but are not limited to the following:
 ** <ul>
 ** <li> The [PRAGMA writable_schema=ON] statement.
+** <li> The [PRAGMA journal_mode=OFF] statement.
 ** <li> Writes to the [sqlite_dbpage] virtual table.
 ** <li> Direct writes to [shadow tables].
 ** </ul>
@@ -2213,6 +2220,34 @@ struct sqlite3_mem_methods {
 ** integer into which is written 0 or 1 to indicate whether the writable_schema
 ** is enabled or disabled following this call.
 ** </dd>
+**
+** [[SQLITE_DBCONFIG_LEGACY_ALTER_TABLE]]
+** <dt>SQLITE_DBCONFIG_LEGACY_ALTER_TABLE</dt>
+** <dd>The SQLITE_DBCONFIG_LEGACY_ALTER_TABLE option activates or deactivates
+** the legacy behavior of the [ALTER TABLE RENAME] command such it
+** behaves as it did prior to [version 3.24.0] (2018-06-04).  See the
+** "Compatibility Notice" on the [ALTER TABLE RENAME documentation] for
+** additional information. This feature can also be turned on and off
+** using the [PRAGMA legacy_alter_table] statement.
+** </dd>
+**
+** [[SQLITE_DBCONFIG_DQS_DML]]
+** <dt>SQLITE_DBCONFIG_DQS_DML</td>
+** <dd>The SQLITE_DBCONFIG_DQS_DML option activates or deactivates
+** the legacy [double-quoted string literal] misfeature for DML statement
+** only, that is DELETE, INSERT, SELECT, and UPDATE statements. The
+** default value of this setting is determined by the [-DSQLITE_DQS]
+** compile-time option.
+** </dd>
+**
+** [[SQLITE_DBCONFIG_DQS_DDL]]
+** <dt>SQLITE_DBCONFIG_DQS_DDL</td>
+** <dd>The SQLITE_DBCONFIG_DQS option activates or deactivates
+** the legacy [double-quoted string literal] misfeature for DDL statements,
+** such as CREATE TABLE and CREATE INDEX. The
+** default value of this setting is determined by the [-DSQLITE_DQS]
+** compile-time option.
+** </dd>
 ** </dl>
 */
 #define SQLITE_DBCONFIG_MAINDBNAME            1000 /* const char* */
@@ -2227,7 +2262,10 @@ struct sqlite3_mem_methods {
 #define SQLITE_DBCONFIG_RESET_DATABASE        1009 /* int int* */
 #define SQLITE_DBCONFIG_DEFENSIVE             1010 /* int int* */
 #define SQLITE_DBCONFIG_WRITABLE_SCHEMA       1011 /* int int* */
-#define SQLITE_DBCONFIG_MAX                   1011 /* Largest DBCONFIG */
+#define SQLITE_DBCONFIG_LEGACY_ALTER_TABLE    1012 /* int int* */
+#define SQLITE_DBCONFIG_DQS_DML               1013 /* int int* */
+#define SQLITE_DBCONFIG_DQS_DDL               1014 /* int int* */
+#define SQLITE_DBCONFIG_MAX                   1014 /* Largest DBCONFIG */
 
 /*
 ** CAPI3REF: Enable Or Disable Extended Result Codes
@@ -7319,7 +7357,8 @@ SQLITE_API int sqlite3_test_control(int op, ...);
 #define SQLITE_TESTCTRL_SORTER_MMAP             24
 #define SQLITE_TESTCTRL_IMPOSTER                25
 #define SQLITE_TESTCTRL_PARSER_COVERAGE         26
-#define SQLITE_TESTCTRL_LAST                    26  /* Largest TESTCTRL */
+#define SQLITE_TESTCTRL_RESULT_INTREAL          27
+#define SQLITE_TESTCTRL_LAST                    27  /* Largest TESTCTRL */
 
 /*
 ** CAPI3REF: SQL Keyword Checking

--- a/sqlitex/exec.go
+++ b/sqlitex/exec.go
@@ -115,7 +115,6 @@ func exec(stmt *sqlite.Stmt, resultFn func(stmt *sqlite.Stmt) error, args []inte
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 			stmt.BindInt64(i, v.Int())
 		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
-
 			stmt.BindInt64(i, int64(v.Uint()))
 		case reflect.Float32, reflect.Float64:
 			stmt.BindFloat(i, v.Float())

--- a/sqlitex/exec_test.go
+++ b/sqlitex/exec_test.go
@@ -111,8 +111,8 @@ func TestExecScript(t *testing.T) {
 
 	script := `
 CREATE TABLE t (a TEXT, b INTEGER);
-INSERT INTO t (a, b) VALUES ("a1", 1);
-INSERT INTO t (a, b) VALUES ("a2", 2);
+INSERT INTO t (a, b) VALUES ('a1', 1);
+INSERT INTO t (a, b) VALUES ('a2', 2);
 `
 
 	if err := sqlitex.ExecScript(conn, script); err != nil {

--- a/sqlitex/pool_test.go
+++ b/sqlitex/pool_test.go
@@ -157,7 +157,7 @@ func TestSharedCacheLock(t *testing.T) {
 		CREATE TABLE t (c, content BLOB);
 		DROP TABLE IF EXISTS t2;
 		CREATE TABLE t2 (c);
-		INSERT INTO t2 (c) VALUES ("hello");
+		INSERT INTO t2 (c) VALUES ('hello');
 		`)
 	if err != nil {
 		t.Fatal(err)

--- a/sqlitex/savepoint_test.go
+++ b/sqlitex/savepoint_test.go
@@ -50,7 +50,7 @@ func TestExec(t *testing.T) {
 	insert := func(succeed bool) (err error) {
 		defer Save(conn)(&err)
 
-		if err := Exec(conn, `INSERT INTO t VALUES ("hello");`, nil); err != nil {
+		if err := Exec(conn, `INSERT INTO t VALUES ('hello');`, nil); err != nil {
 			t.Fatal(err)
 		}
 
@@ -90,7 +90,7 @@ func TestPanic(t *testing.T) {
 	if err := Exec(conn, "CREATE TABLE t (c1);", nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := Exec(conn, `INSERT INTO t VALUES ("one");`, nil); err != nil {
+	if err := Exec(conn, `INSERT INTO t VALUES ('one');`, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -124,7 +124,7 @@ func TestPanic(t *testing.T) {
 func doPanic(conn *sqlite.Conn) (err error) {
 	defer Save(conn)(&err)
 
-	if err := Exec(conn, `INSERT INTO t VALUES ("hello");`, nil); err != nil {
+	if err := Exec(conn, `INSERT INTO t VALUES ('hello');`, nil); err != nil {
 		return err
 	}
 
@@ -183,7 +183,7 @@ func TestReleaseTx(t *testing.T) {
 	insert := func(succeed bool) (err error) {
 		defer Save(conn1)(&err)
 
-		if err := Exec(conn1, `INSERT INTO t VALUES ("hello");`, nil); err != nil {
+		if err := Exec(conn1, `INSERT INTO t VALUES ('hello');`, nil); err != nil {
 			t.Fatal(err)
 		}
 
@@ -296,7 +296,7 @@ func TestBusySnapshot(t *testing.T) {
 	if err = ExecScript(conn0, `
 		DROP TABLE IF EXISTS t;
 		CREATE TABLE t (c, b BLOB);
-		INSERT INTO t (c, b) VALUES (4, "hi");
+		INSERT INTO t (c, b) VALUES (4, 'hi');
 	`); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Add compile time flag -DSQLITE_DQS=0 which disables all double quoted
string literals by default. Fine grained control of how DQS are parsed
is exposed with Conn.EnableDoubleQuotedStringLiterals().

Close #69 