### PR TITLE
Check autocommit mode prior to RELEASE/ROLLBACK

### DIFF
--- a/sqlite.go
+++ b/sqlite.go
@@ -194,6 +194,10 @@ func (conn *Conn) Close() error {
 	return reserr("Conn.Close", "", "", res)
 }
 
+func (conn *Conn) GetAutocommit() bool {
+	return int(C.sqlite3_get_autocommit(conn.conn)) != 0
+}
+
 // CheckResult reports whether any statement on this connection
 // is in the process of returning results.
 func (conn *Conn) CheckReset() string {

--- a/sqlitex/savepoint_test.go
+++ b/sqlitex/savepoint_test.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"crawshaw.io/sqlite"
 )
@@ -262,6 +263,97 @@ func TestInterruptRollback(t *testing.T) {
 		t.Fatalf("relaseFn1 errNil=%v, want SQLITE_INTERRUPT", errNil)
 	}
 
+	conn.SetInterrupt(nil)
+	got, err := ResultInt(conn.Prep("SELECT count(*) FROM t;"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 1 {
+		t.Errorf("want 1 row, got %d", got)
+	}
+}
+
+var veryLongScript = `
+drop table if exists naturals;
+create table naturals
+( n integer unique primary key asc,
+  isprime bool,
+  factor integer);
+
+with recursive
+  nn (n)
+as (
+  select 2
+  union all
+  select n+1 as newn from nn
+  where newn < 1e10
+)
+insert into naturals
+select n, 1, null from nn;
+
+insert or replace into naturals
+  with recursive
+    product (prime,composite)
+  as (
+    select n, n*n as sqr
+      from naturals
+      where sqr <= (select max(n) from naturals)
+    union all
+    select prime, composite+prime as prod
+    from
+      product
+    where
+      prod <= (select max(n) from naturals)
+  )
+select n, 0, prime
+from product join naturals
+  on (product.composite = naturals.n)
+;
+`
+
+func TestInterruptRollbackLongQuery(t *testing.T) {
+	conn, err := sqlite.OpenConn("file::memory:?mode=memory&cache=shared", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	if err = ExecScript(conn, `
+		DROP TABLE IF EXISTS t;
+		CREATE TABLE t (c);
+	`); err != nil {
+		t.Fatal(err)
+	}
+
+	releaseFn := Save(conn)
+	if err := Exec(conn, `INSERT INTO t (c) VALUES (1);`, nil); err != nil {
+		t.Fatal(err)
+	}
+	releaseFn(&err)
+	if err != nil {
+		t.Fatalf("relaseFn err: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	conn.SetInterrupt(ctx.Done())
+	testDone := make(chan struct{})
+	go func() {
+		defer close(testDone)
+		defer func() {
+			if err := recover(); err != nil {
+				t.Log("a panic occurred during rollback\n", err)
+				t.Fail()
+			}
+		}()
+		defer Save(conn)(&err)
+		if err := Exec(conn, `INSERT INTO t (c) VALUES (3);`, nil); err != nil {
+			t.Fatalf("interrupted too early")
+		}
+		err = ExecScript(conn, veryLongScript)
+	}()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	<-testDone
 	conn.SetInterrupt(nil)
 	got, err := ResultInt(conn.Prep("SELECT count(*) FROM t;"))
 	if err != nil {


### PR DESCRIPTION
When a query that is within an explicit transaction is interrupted, the
entire transaction is automatically rolled back. However the releaseFn
returned by sqlitex.Save previously would still RELEASE/ROLLBACK the
transaction, which would result in a "no such savepoint" error and
subsequent panic from the deferred releaseFn.

This commit introduces a test that reproduced this panic and a fix that
avoids it. To reproduce the panic, comment out the added lines in
savepoint.go and run the RollbackInterruptLongQuery test.

The fix is simple: check whether we are still within a transaction
before attempting RELEASE/ROLLBACK. This is checked using the
sqlite3_get_autocommit() C function, which is now exposed via
Conn.GetAutocommit.

Fix #73 