### PR TITLE
fix vendoring with `go mod vendor`

### DIFF
--- a/c/dummy.go
+++ b/c/dummy.go
@@ -1,0 +1,3 @@
+// +build dummy
+
+package c

--- a/c/dummy.go
+++ b/c/dummy.go
@@ -1,3 +1,7 @@
 // +build dummy
 
+// Package c contains only a C file.
+//
+// This Go file is part of a workaround for `go mod vendor`.
+// Please see the file dummy.go at the root of the module for more information.
 package c

--- a/dummy.go
+++ b/dummy.go
@@ -1,0 +1,7 @@
+// +build dummy
+
+package sqlite
+
+import (
+	_ "crawshaw.io/sqlite/c"
+)

--- a/dummy.go
+++ b/dummy.go
@@ -1,5 +1,16 @@
 // +build dummy
 
+// This file is part of a workaround for `go mod vendor` which won't vendor
+// C files if there's no Go file in the same directory.
+// This would prevent the c/sqlite3.c file to be vendored.
+//
+// This Go file imports the c directory where there is another dummy.go file which
+// is the second part of this workaround.
+//
+// These two files combined make it so `go mod vendor` behaves correctly.
+//
+// See this issue for reference: https://github.com/golang/go/issues/26366
+
 package sqlite
 
 import (


### PR DESCRIPTION
A directory with a single C file in it will not be vendored by `go mod vendor`, see [this issue](https://github.com/golang/go/issues/26366).

This commits adds a workaround by putting dummy Go files which makes go mod behave correctly.

It's not ideal but I don't see another way (other than requiring users to manually copy the file in their vendor directory).