### PR TITLE
Always uses extended errors for constraints.

### DIFF
--- a/sqlite.go
+++ b/sqlite.go
@@ -676,7 +676,7 @@ func (stmt *Stmt) step() (bool, error) {
 			return true, nil
 		case C.SQLITE_DONE:
 			return false, nil
-		case C.SQLITE_INTERRUPT, C.SQLITE_CONSTRAINT:
+		case C.SQLITE_INTERRUPT:
 			// TODO: embed some of these errors into the stmt for zero-alloc errors?
 			return false, stmt.conn.reserr("Stmt.Step", stmt.query, res)
 		default:


### PR DESCRIPTION
In #5 the ErrCode return was fixed to always return the correct code.
But the Error.Msg field remains empty. Returning the extended error
allows checking for a named constraint. For example:

```
  CREATE TABLE IF NOT EXISTS users (
    email text NOT NULL DEFAULT '',
    CONSTRAINT not_empty_email CHECK (email != '')
  );
```
Calling Step() with an empty value, returns the following Error.Msg:

```
  CHECK constraint failed: not_empty_email
```

The extended error is useful in cases like form validation.