### PR TITLE
Fix race in sqlitex.Pool Get and Close

### DIFF
--- a/sqlitex/pool.go
+++ b/sqlitex/pool.go
@@ -129,6 +129,7 @@ func (p *Pool) Get(ctx context.Context) *sqlite.Conn {
 	var cancel context.CancelFunc
 	ctx, cancel = context.WithCancel(ctx)
 
+outer:
 	select {
 	case conn := <-p.free:
 		p.mu.Lock()
@@ -137,7 +138,7 @@ func (p *Pool) Get(ctx context.Context) *sqlite.Conn {
 		select {
 		case <-p.closed:
 			p.free <- conn
-			break
+			break outer
 		default:
 		}
 


### PR DESCRIPTION
There's a race condition in sqlitex.Pool's Get and Close. I think it was intended that if we pull a free Conn while holding the pool mutex, we push it back, and then proceed to immediately cancel the current context and return. Instead we were accidentally breaking to the current scope, and returning the free connection despite having returned it to be cleaned up. This leads to segfaults in the C code down the track as we end up trying to use a Conn that has already been closed.