### PR TITLE
Add Stmt.BindParamName method

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -22,7 +22,6 @@ func InterruptedStmt(conn *Conn, query string) *Stmt {
 	return &Stmt{
 		conn:          conn,
 		query:         query,
-		bindNames:     make(map[string]int),
 		colNames:      make(map[string]int),
 		prepInterrupt: true,
 	}

--- a/sqlite.go
+++ b/sqlite.go
@@ -850,7 +850,8 @@ func (stmt *Stmt) BindNull(param int) {
 	stmt.handleBindErr("BindNull", res)
 }
 
-// BindNull binds a blob of zeros of length len to a numbered stmt parameter.
+// BindZeroBlob binds a blob of zeros of length len to a numbered stmt
+// parameter.
 //
 // Parameter indices start at 1.
 //

--- a/sqlite.go
+++ b/sqlite.go
@@ -438,7 +438,7 @@ func (conn *Conn) prepare(query string, flags C.uint) (*Stmt, int, error) {
 	}
 	trailingBytes := int(C.strlen(ctrailing))
 
-	stmt.bindNames = make([]string, stmt.BindParamCount())
+	stmt.bindNames = make([]string, int(C.sqlite3_bind_parameter_count(stmt.stmt)))
 	for i := range stmt.bindNames {
 		cname := C.sqlite3_bind_parameter_name(stmt.stmt, C.int(i+1))
 		if cname != nil {
@@ -733,7 +733,7 @@ func (stmt *Stmt) BindParamCount() int {
 	if stmt.stmt == nil {
 		return 0
 	}
-	return int(C.sqlite3_bind_parameter_count(stmt.stmt))
+	return len(stmt.bindNames)
 }
 
 // BindParamName returns the name of parameter or the empty string if the


### PR DESCRIPTION
I changed `Stmt.bindNames` to a slice, since the elements are a small, contiguous sequence.