### PR TITLE
Set busy timeout before setting journal mode on new connections

### DIFF
--- a/sqlite.go
+++ b/sqlite.go
@@ -153,6 +153,10 @@ func openConn(path string, flags ...OpenFlags) (*Conn, error) {
 		}
 	})
 
+	// Large timeout as Go programs should control timeouts
+	// using SetInterrupt. Documented in SetBusyTimeout.
+	conn.SetBusyTimeout(10 * time.Second)
+
 	if openFlags&SQLITE_OPEN_WAL > 0 {
 		stmt, _, err := conn.PrepareTransient("PRAGMA journal_mode=wal;")
 		if err != nil {
@@ -166,9 +170,6 @@ func openConn(path string, flags ...OpenFlags) (*Conn, error) {
 		}
 	}
 
-	// Large timeout as Go programs should control timeouts
-	// using SetInterrupt. Documented in SetBusyTimeout.
-	conn.SetBusyTimeout(10 * time.Second)
 
 	return conn, nil
 }


### PR DESCRIPTION
In a large project using crawshaw.io/sqlite (from https://github.com/getlantern/sqlite/tree/busy-openconn), `SQLITE_BUSY_RECOVERY` is sometimes seen while calling `sqlitex.Open` in the form `sqlite.Conn.Prepare: SQLITE_BUSY_RECOVERY: database is locked (PRAGMA journal_mode=wal;)`. I believe this could be avoidable by setting the busy handler before attempting to set the journal mode on newly opened connections.