### PR TITLE
implement GetType(string) ColumnType

### DIFF
--- a/sqlite.go
+++ b/sqlite.go
@@ -1054,6 +1054,15 @@ func (stmt *Stmt) ColumnIndex(colName string) int {
 	return col
 }
 
+// GetType returns a query result type for colName
+func (stmt *Stmt) GetType(colName string) ColumnType {
+	col, found := stmt.colNames[colName]
+	if !found {
+		return SQLITE_NULL
+	}
+	return stmt.ColumnType(col)
+}
+
 // GetInt64 returns a query result value for colName as an int64.
 func (stmt *Stmt) GetInt64(colName string) int64 {
 	col, found := stmt.colNames[colName]

--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -103,9 +103,15 @@ func TestConn(t *testing.T) {
 		if typ != sqlite.SQLITE_TEXT {
 			t.Errorf(`ColumnType(0)=%q, want %q`, typ, sqlite.SQLITE_TEXT)
 		}
+		if getType := stmt.GetType("foo1"); getType != typ {
+			t.Errorf(`GetType("foo1")=%q, want %q`, getType, typ)
+		}
 		intTyp := stmt.ColumnType(1)
 		if intTyp != sqlite.SQLITE_INTEGER {
 			t.Errorf(`ColumnType(1)=%q, want %q`, intTyp, sqlite.SQLITE_INTEGER)
+		}
+		if getIntType := stmt.GetType("foo2"); getIntType != intTyp {
+			t.Errorf(`GetType("foo2")=%q, want %q`, getIntType, intTyp)
 		}
 		gotVals = append(gotVals, val)
 		gotInts = append(gotInts, intVal)


### PR DESCRIPTION
Almost every `Column*` has its equivalent in `Get*` except for a few methods. Since the type information are heavily used to check for a `NULL` value. `GetType` provides a convenient method to access it without knowing the column index.