### PR TITLE
Bind non-nil empty slices as empty blobs, not NULL

### DIFF
--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -409,16 +409,6 @@ func TestBindBytes(t *testing.T) {
 
 	stmt.Reset()
 
-	stmt.SetBytes("$bytes", val)
-	if hasRow, err := stmt.Step(); err != nil {
-		t.Fatal(err)
-	} else if !hasRow {
-		t.Error("SetBytes: result has no row")
-	}
-	if got := stmt.ColumnInt(0); got != 1 {
-		t.Errorf("SetBytes: count is %d, want 1", got)
-	}
-
 	blob, err := c.OpenBlob("", "bindbytes", "c", 1, false)
 	if err != nil {
 		t.Fatalf("SetBytes: OpenBlob: %v", err)


### PR DESCRIPTION
`stmt.BindBytes(col, make([]byte, 0))` now stores an empty blob, instead of a `NULL`.
    
`stmt.BindBytes(col, nil)` will still store a `NULL`. This is intentional, to mimic `sqlite3_bind_blob`'s behaviour with `NULL` pointers.

This fixes #117.