### PR TITLE
Export sqlitex errors to allow handling with errors.Is

### DIFF
--- a/sqlitex/query.go
+++ b/sqlitex/query.go
@@ -37,11 +37,13 @@ func resultTeardown(stmt *sqlite.Stmt) error {
 
 // ResultInt steps the Stmt once and returns the first column as an int.
 //
-// If there are no rows in the result set, errors.Is(ErrNoResults) will
-// be true.
+// If there are no rows in the result set, ErrNoResults is returned.
 //
-// If there are multiple rows, errors.Is(ErrMultipleResults) will be true.
+// If there are multiple rows, ErrMultipleResults is returned with the first
+// result.
 //
+// The Stmt is always Reset, so repeated calls will always return the first
+// result.
 func ResultInt(stmt *sqlite.Stmt) (int, error) {
 	res, err := ResultInt64(stmt)
 	return int(res), err
@@ -49,54 +51,48 @@ func ResultInt(stmt *sqlite.Stmt) (int, error) {
 
 // ResultInt64 steps the Stmt once and returns the first column as an int64.
 //
-// If there are no rows in the result set, errors.Is(ErrNoResults) will
-// be true.
+// If there are no rows in the result set, ErrNoResults is returned.
 //
-// If there are multiple rows, errors.Is(ErrMultipleResults) will be true.
+// If there are multiple rows, ErrMultipleResults is returned with the first
+// result.
 //
+// The Stmt is always Reset, so repeated calls will always return the first
+// result.
 func ResultInt64(stmt *sqlite.Stmt) (int64, error) {
 	if err := resultSetup(stmt); err != nil {
 		return 0, err
 	}
-	res := stmt.ColumnInt64(0)
-	if err := resultTeardown(stmt); err != nil {
-		return 0, err
-	}
-	return res, nil
+	return stmt.ColumnInt64(0), resultTeardown(stmt)
 }
 
 // ResultText steps the Stmt once and returns the first column as a string.
 //
-// If there are no rows in the result set, errors.Is(ErrNoResults) will
-// be true.
+// If there are no rows in the result set, ErrNoResults is returned.
 //
-// If there are multiple rows, errors.Is(ErrMultipleResults) will be true.
+// If there are multiple rows, ErrMultipleResults is returned with the first
+// result.
 //
+// The Stmt is always Reset, so repeated calls will always return the first
+// result.
 func ResultText(stmt *sqlite.Stmt) (string, error) {
 	if err := resultSetup(stmt); err != nil {
 		return "", err
 	}
-	res := stmt.ColumnText(0)
-	if err := resultTeardown(stmt); err != nil {
-		return "", err
-	}
-	return res, nil
+	return stmt.ColumnText(0), resultTeardown(stmt)
 }
 
-// ResultFloat steps the Stmt once and returns the first column as a loat.
+// ResultFloat steps the Stmt once and returns the first column as a float64.
 //
-// If there are no rows in the result set, errors.Is(ErrNoResults) will
-// be true.
+// If there are no rows in the result set, ErrNoResults is returned.
 //
-// If there are multiple rows, errors.Is(ErrMultipleResults) will be true.
+// If there are multiple rows, ErrMultipleResults is returned with the first
+// result.
 //
+// The Stmt is always Reset, so repeated calls will always return the first
+// result.
 func ResultFloat(stmt *sqlite.Stmt) (float64, error) {
 	if err := resultSetup(stmt); err != nil {
 		return 0, err
 	}
-	res := stmt.ColumnFloat(0)
-	if err := resultTeardown(stmt); err != nil {
-		return 0, err
-	}
-	return res, nil
+	return stmt.ColumnFloat(0), resultTeardown(stmt)
 }

--- a/sqlitex/query.go
+++ b/sqlitex/query.go
@@ -6,8 +6,8 @@ import (
 	"crawshaw.io/sqlite"
 )
 
-var errNoResults = errors.New("sqlite: statement has no results")
-var errMultipleResults = errors.New("sqlite: statement has multiple result rows")
+var ErrNoResults = errors.New("sqlite: statement has no results")
+var ErrMultipleResults = errors.New("sqlite: statement has multiple result rows")
 
 func resultSetup(stmt *sqlite.Stmt) error {
 	hasRow, err := stmt.Step()
@@ -17,7 +17,7 @@ func resultSetup(stmt *sqlite.Stmt) error {
 	}
 	if !hasRow {
 		stmt.Reset()
-		return errNoResults
+		return ErrNoResults
 	}
 	return nil
 }
@@ -30,7 +30,7 @@ func resultTeardown(stmt *sqlite.Stmt) error {
 	}
 	if hasRow {
 		stmt.Reset()
-		return errMultipleResults
+		return ErrMultipleResults
 	}
 	return stmt.Reset()
 }

--- a/sqlitex/query.go
+++ b/sqlitex/query.go
@@ -35,11 +35,25 @@ func resultTeardown(stmt *sqlite.Stmt) error {
 	return stmt.Reset()
 }
 
+// ResultInt steps the Stmt once and returns the first column as an int.
+//
+// If there are no rows in the result set, errors.Is(ErrNoResults) will
+// be true.
+//
+// If there are multiple rows, errors.Is(ErrMultipleResults) will be true.
+//
 func ResultInt(stmt *sqlite.Stmt) (int, error) {
 	res, err := ResultInt64(stmt)
 	return int(res), err
 }
 
+// ResultInt64 steps the Stmt once and returns the first column as an int64.
+//
+// If there are no rows in the result set, errors.Is(ErrNoResults) will
+// be true.
+//
+// If there are multiple rows, errors.Is(ErrMultipleResults) will be true.
+//
 func ResultInt64(stmt *sqlite.Stmt) (int64, error) {
 	if err := resultSetup(stmt); err != nil {
 		return 0, err
@@ -51,6 +65,13 @@ func ResultInt64(stmt *sqlite.Stmt) (int64, error) {
 	return res, nil
 }
 
+// ResultText steps the Stmt once and returns the first column as a string.
+//
+// If there are no rows in the result set, errors.Is(ErrNoResults) will
+// be true.
+//
+// If there are multiple rows, errors.Is(ErrMultipleResults) will be true.
+//
 func ResultText(stmt *sqlite.Stmt) (string, error) {
 	if err := resultSetup(stmt); err != nil {
 		return "", err
@@ -62,6 +83,13 @@ func ResultText(stmt *sqlite.Stmt) (string, error) {
 	return res, nil
 }
 
+// ResultFloat steps the Stmt once and returns the first column as a loat.
+//
+// If there are no rows in the result set, errors.Is(ErrNoResults) will
+// be true.
+//
+// If there are multiple rows, errors.Is(ErrMultipleResults) will be true.
+//
 func ResultFloat(stmt *sqlite.Stmt) (float64, error) {
 	if err := resultSetup(stmt); err != nil {
 		return 0, err

--- a/sqlitex/query_test.go
+++ b/sqlitex/query_test.go
@@ -40,7 +40,7 @@ func TestResult(t *testing.T) {
 		}
 	}
 
-	t.Run("int64/result", func(t *testing.T) {
+	t.Run("Int64/Result", func(t *testing.T) {
 		_, ins, sel, done := setup(t)
 		defer done()
 
@@ -58,7 +58,7 @@ func TestResult(t *testing.T) {
 		}
 	})
 
-	t.Run("int64/astext", func(t *testing.T) {
+	t.Run("Int64/AsText", func(t *testing.T) {
 		_, ins, sel, done := setup(t)
 		defer done()
 
@@ -76,7 +76,7 @@ func TestResult(t *testing.T) {
 		}
 	})
 
-	t.Run("int64/errmultipleresults", func(t *testing.T) {
+	t.Run("Int64/ErrMultipleResults", func(t *testing.T) {
 		_, ins, sel, done := setup(t)
 		defer done()
 
@@ -104,7 +104,7 @@ func TestResult(t *testing.T) {
 		}
 	})
 
-	t.Run("int64/errnoresult", func(t *testing.T) {
+	t.Run("Int64/ErrNoResult", func(t *testing.T) {
 		_, _, sel, done := setup(t)
 		defer done()
 
@@ -117,7 +117,7 @@ func TestResult(t *testing.T) {
 		}
 	})
 
-	t.Run("float/result", func(t *testing.T) {
+	t.Run("Float/Result", func(t *testing.T) {
 		_, ins, sel, done := setup(t)
 		defer done()
 
@@ -135,7 +135,7 @@ func TestResult(t *testing.T) {
 		}
 	})
 
-	t.Run("float/errmultipleresults", func(t *testing.T) {
+	t.Run("Float/ErrMultipleResults", func(t *testing.T) {
 		_, ins, sel, done := setup(t)
 		defer done()
 
@@ -162,7 +162,7 @@ func TestResult(t *testing.T) {
 		}
 	})
 
-	t.Run("float/errnoresult", func(t *testing.T) {
+	t.Run("Float/ErrNoResult", func(t *testing.T) {
 		_, _, sel, done := setup(t)
 		defer done()
 
@@ -175,7 +175,7 @@ func TestResult(t *testing.T) {
 		}
 	})
 
-	t.Run("text/result", func(t *testing.T) {
+	t.Run("Text/Result", func(t *testing.T) {
 		_, ins, sel, done := setup(t)
 		defer done()
 
@@ -193,7 +193,7 @@ func TestResult(t *testing.T) {
 		}
 	})
 
-	t.Run("text/errmultipleresults", func(t *testing.T) {
+	t.Run("Text/ErrMultipleResults", func(t *testing.T) {
 		_, ins, sel, done := setup(t)
 		defer done()
 
@@ -220,7 +220,7 @@ func TestResult(t *testing.T) {
 		}
 	})
 
-	t.Run("text/errnoresult", func(t *testing.T) {
+	t.Run("Text/ErrNoResult", func(t *testing.T) {
 		_, _, sel, done := setup(t)
 		defer done()
 
@@ -233,7 +233,7 @@ func TestResult(t *testing.T) {
 		}
 	})
 
-	t.Run("text/asint64", func(t *testing.T) {
+	t.Run("Text/AsInt64", func(t *testing.T) {
 		_, ins, sel, done := setup(t)
 		defer done()
 

--- a/sqlitex/query_test.go
+++ b/sqlitex/query_test.go
@@ -1,0 +1,253 @@
+package sqlitex
+
+import (
+	"fmt"
+	"testing"
+
+	"crawshaw.io/sqlite"
+)
+
+func TestResult(t *testing.T) {
+	setup := func(t *testing.T) (conn *sqlite.Conn, ins, sel *sqlite.Stmt, done func()) {
+		t.Helper()
+		conn, err := sqlite.OpenConn(":memory:", 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := Exec(conn, "CREATE TABLE t (c1);", nil); err != nil {
+			conn.Close()
+			t.Fatal(err)
+		}
+
+		ins, err = conn.Prepare("INSERT INTO t (c1) VALUES ($c1);")
+		if err != nil {
+			conn.Close()
+			t.Fatal(err)
+		}
+
+		sel, _, err = conn.PrepareTransient("SELECT c1 FROM t")
+		if err != nil {
+			ins.Finalize()
+			conn.Close()
+			t.Fatal(err)
+		}
+
+		return conn, ins, sel, func() {
+			ins.Finalize()
+			sel.Finalize()
+			conn.Close()
+		}
+	}
+
+	t.Run("int64/result", func(t *testing.T) {
+		_, ins, sel, done := setup(t)
+		defer done()
+
+		input := int64(1234)
+		ins.SetInt64("$c1", input)
+		if _, err := ins.Step(); err != nil {
+			t.Fatal(err)
+		}
+		result, err := ResultInt64(sel)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result != input {
+			t.Fatal()
+		}
+	})
+
+	t.Run("int64/astext", func(t *testing.T) {
+		_, ins, sel, done := setup(t)
+		defer done()
+
+		input := int64(1234)
+		ins.SetInt64("$c1", input)
+		if _, err := ins.Step(); err != nil {
+			t.Fatal(err)
+		}
+		result, err := ResultText(sel)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result != fmt.Sprint(input) {
+			t.Fatal(result, "!=", input)
+		}
+	})
+
+	t.Run("int64/errmultipleresults", func(t *testing.T) {
+		_, ins, sel, done := setup(t)
+		defer done()
+
+		ins.SetInt64("$c1", int64(1234))
+		if _, err := ins.Step(); err != nil {
+			t.Fatal(err)
+		}
+		if err := ins.Reset(); err != nil {
+			t.Fatal(err)
+		}
+		ins.SetInt64("$c1", int64(5678))
+		if _, err := ins.Step(); err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := ResultInt64(sel)
+		if result != 0 {
+			t.Fatal()
+		}
+
+		// XXX: Using direct equality check as go.mod specifies Go 1.12, which does not
+		// have errors.Is. When go.mod is updated past 1.12, this should use errors.Is.
+		if err != ErrMultipleResults {
+			t.Fatal("err != ErrMultipleResults", err)
+		}
+	})
+
+	t.Run("int64/errnoresult", func(t *testing.T) {
+		_, _, sel, done := setup(t)
+		defer done()
+
+		result, err := ResultInt64(sel)
+		if result != 0 {
+			t.Fatal()
+		}
+		if err != ErrNoResults {
+			t.Fatal("err != ErrNoResults", err)
+		}
+	})
+
+	t.Run("float/result", func(t *testing.T) {
+		_, ins, sel, done := setup(t)
+		defer done()
+
+		input := float64(1234)
+		ins.SetFloat("$c1", input)
+		if _, err := ins.Step(); err != nil {
+			t.Fatal(err)
+		}
+		result, err := ResultFloat(sel)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result != input {
+			t.Fatal()
+		}
+	})
+
+	t.Run("float/errmultipleresults", func(t *testing.T) {
+		_, ins, sel, done := setup(t)
+		defer done()
+
+		ins.SetFloat("$c1", 123.4)
+		if _, err := ins.Step(); err != nil {
+			t.Fatal(err)
+		}
+		if err := ins.Reset(); err != nil {
+			t.Fatal(err)
+		}
+		ins.SetFloat("$c1", 567.8)
+		if _, err := ins.Step(); err != nil {
+			t.Fatal(err)
+		}
+		result, err := ResultFloat(sel)
+		if result != 0 {
+			t.Fatal()
+		}
+
+		// XXX: Using direct equality check as go.mod specifies Go 1.12, which does not
+		// have errors.Is. When go.mod is updated past 1.12, this should use errors.Is.
+		if err != ErrMultipleResults {
+			t.Fatal("err != ErrMultipleResults", err)
+		}
+	})
+
+	t.Run("float/errnoresult", func(t *testing.T) {
+		_, _, sel, done := setup(t)
+		defer done()
+
+		result, err := ResultFloat(sel)
+		if result != 0 {
+			t.Fatal()
+		}
+		if err != ErrNoResults {
+			t.Fatal("err != ErrNoResults", err)
+		}
+	})
+
+	t.Run("text/result", func(t *testing.T) {
+		_, ins, sel, done := setup(t)
+		defer done()
+
+		input := "test"
+		ins.SetText("$c1", input)
+		if _, err := ins.Step(); err != nil {
+			t.Fatal(err)
+		}
+		result, err := ResultText(sel)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result != input {
+			t.Fatal()
+		}
+	})
+
+	t.Run("text/errmultipleresults", func(t *testing.T) {
+		_, ins, sel, done := setup(t)
+		defer done()
+
+		ins.SetText("$c1", "test1")
+		if _, err := ins.Step(); err != nil {
+			t.Fatal(err)
+		}
+		if err := ins.Reset(); err != nil {
+			t.Fatal(err)
+		}
+		ins.SetText("$c1", "test2")
+		if _, err := ins.Step(); err != nil {
+			t.Fatal(err)
+		}
+		result, err := ResultText(sel)
+		if result != "" {
+			t.Fatal()
+		}
+
+		// XXX: Using direct equality check as go.mod specifies Go 1.12, which does not
+		// have errors.Is. When go.mod is updated past 1.12, this should use errors.Is.
+		if err != ErrMultipleResults {
+			t.Fatal("err != ErrMultipleResults", err)
+		}
+	})
+
+	t.Run("text/errnoresult", func(t *testing.T) {
+		_, _, sel, done := setup(t)
+		defer done()
+
+		result, err := ResultText(sel)
+		if result != "" {
+			t.Fatal()
+		}
+		if err != ErrNoResults {
+			t.Fatal("err != ErrNoResults", err)
+		}
+	})
+
+	t.Run("text/asint64", func(t *testing.T) {
+		_, ins, sel, done := setup(t)
+		defer done()
+
+		input := "test"
+		ins.SetText("$c1", input)
+		if _, err := ins.Step(); err != nil {
+			t.Fatal(err)
+		}
+		result, err := ResultInt64(sel)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result != 0 {
+			t.Fatal(result, "!=", 0)
+		}
+	})
+}


### PR DESCRIPTION
This fixes the issue raised in #99. I think just exporting these errors for use with `errors.Is` is the best approach as it doesn't require any build tag stuff to support the pre-errors.Is Go version declared in the `go.mod`.