### PR TITLE
Add sqlitex.OpenInit to allow initializing all Conns in a Pool with a script

### DIFF
--- a/sqlitex/pool.go
+++ b/sqlitex/pool.go
@@ -67,7 +67,7 @@ type Pool struct {
 //	SQLITE_OPEN_WAL
 //	SQLITE_OPEN_URI
 //	SQLITE_OPEN_NOMUTEX
-func Open(uri string, flags sqlite.OpenFlags, poolSize int, initScripts ...string) (pool *Pool, err error) {
+func Open(uri string, flags sqlite.OpenFlags, poolSize int) (pool *Pool, err error) {
 	return OpenInit(nil, uri, flags, poolSize, "")
 }
 

--- a/sqlitex/pool.go
+++ b/sqlitex/pool.go
@@ -187,7 +187,10 @@ func (p *Pool) Put(conn *sqlite.Conn) {
 	p.free <- conn
 }
 
-// PoolCloseTimeout is the
+// PoolCloseTimeout is the maximum time for Pool.Close to wait for all Conns to
+// be returned to the Pool.
+//
+// Do not modify this concurrently with calling Pool.Close.
 var PoolCloseTimeout = 5 * time.Second
 
 // Close interrupts and closes all the connections in the Pool.

--- a/sqlitex/pool.go
+++ b/sqlitex/pool.go
@@ -59,6 +59,7 @@ type Pool struct {
 }
 
 // Open opens a fixed-size pool of SQLite connections.
+//
 // A flags value of 0 defaults to:
 //
 //	SQLITE_OPEN_READWRITE
@@ -66,7 +67,29 @@ type Pool struct {
 //	SQLITE_OPEN_WAL
 //	SQLITE_OPEN_URI
 //	SQLITE_OPEN_NOMUTEX
-func Open(uri string, flags sqlite.OpenFlags, poolSize int) (pool *Pool, err error) {
+func Open(uri string, flags sqlite.OpenFlags, poolSize int, initScripts ...string) (pool *Pool, err error) {
+	return OpenInit(nil, uri, flags, poolSize, "")
+}
+
+// OpenInit opens a fixed-size pool of SQLite connections, each initialized
+// with initScript.
+//
+// A flags value of 0 defaults to:
+//
+//	SQLITE_OPEN_READWRITE
+//	SQLITE_OPEN_CREATE
+//	SQLITE_OPEN_WAL
+//	SQLITE_OPEN_URI
+//	SQLITE_OPEN_NOMUTEX
+//
+// Each initScript is run an all Conns in the Pool. This is intended for PRAGMA
+// or CREATE TEMP VIEW which need to be run on all connections.
+//
+// WARNING: Ensure all queries in initScript are completely idempotent, meaning
+// that running it multiple times is the same as running it once. For example
+// do not run INSERT in any of the initScripts or else it may create duplicate
+// data unintentionally or fail.
+func OpenInit(ctx context.Context, uri string, flags sqlite.OpenFlags, poolSize int, initScript string) (pool *Pool, err error) {
 	if uri == ":memory:" {
 		return nil, strerror{msg: `sqlite: ":memory:" does not work with multiple connections, use "file::memory:?mode=memory"`}
 	}
@@ -103,6 +126,14 @@ func Open(uri string, flags sqlite.OpenFlags, poolSize int) (pool *Pool, err err
 		}
 		p.free <- conn
 		p.all[conn] = func() {}
+
+		if initScript != "" {
+			conn.SetInterrupt(ctx.Done())
+			if err := ExecScript(conn, initScript); err != nil {
+				return nil, err
+			}
+			conn.SetInterrupt(nil)
+		}
 	}
 
 	return p, nil


### PR DESCRIPTION
Many settings need to be set for all Conns every time they are opened. Some examples are per connection `PRAGMA`s or running `CREATE VIEW`. This is a tad cumbersome to do for all connections in a Pool. 

This `sqlitex.OpenInit` adds the ability to provide an initScript to be run on all Conns when opening a pool. A context.Context can be provided so that a timeout on the initScript can be enforced.

Now `sqlitex.Open` is a wrapper of `sqlitex.OpenInit` with an empty script and nil context.

fix #101