### PR TITLE
Remove forward declarations to cgo exported funcs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,4 +53,4 @@ https://godoc.org/crawshaw.io/sqlite
 
 ## Platform specific considerations
 
-By default it requires some pthreads DLL on Windows. To avoid it, supply `CGOLDFLAGS="-static"` when building your application.
+By default it requires some pthreads DLL on Windows. To avoid it, supply `CGO_LDFLAGS="-static"` when building your application.

--- a/auth.go
+++ b/auth.go
@@ -2,8 +2,8 @@ package sqlite
 
 // #include <stdint.h>
 // #include <sqlite3.h>
+// #include "wrappers.h"
 //
-// extern int c_auth_tramp(void*, int, const char*, const char*, const char*, const char*);
 // static int sqlite3_go_set_authorizer(sqlite3* conn, uintptr_t id) {
 //   return sqlite3_set_authorizer(conn, c_auth_tramp, (void*)id);
 // }

--- a/auth.go
+++ b/auth.go
@@ -2,10 +2,8 @@ package sqlite
 
 // #include <stdint.h>
 // #include <sqlite3.h>
-// extern int go_sqlite_auth_tramp(uintptr_t, int, char*, char*, char*, char*);
-// static int c_auth_tramp(void *userData, int action, const char* arg1, const char* arg2, const char* db, const char* trigger) {
-//   return go_sqlite_auth_tramp((uintptr_t)userData, action, (char*)arg1, (char*)arg2, (char*)db, (char*)trigger);
-// }
+//
+// extern int c_auth_tramp(void*, int, const char*, const char*, const char*, const char*);
 // static int sqlite3_go_set_authorizer(sqlite3* conn, uintptr_t id) {
 //   return sqlite3_set_authorizer(conn, c_auth_tramp, (void*)id);
 // }

--- a/func.go
+++ b/func.go
@@ -19,10 +19,6 @@ package sqlite
 // #include <sqlite3.h>
 // #include "wrappers.h"
 //
-// extern void func_tramp(sqlite3_context*, int, sqlite3_value**);
-// extern void step_tramp(sqlite3_context*, int, sqlite3_value**);
-// extern void final_tramp(sqlite3_context*);
-//
 // static int go_sqlite3_create_function_v2(
 //   sqlite3 *db,
 //   const char *zFunctionName,
@@ -167,10 +163,10 @@ func (conn *Conn) CreateFunction(name string, deterministic bool, numArgs int, x
 
 	var funcfn, stepfn, finalfn *[0]byte
 	if xFunc == nil {
-		stepfn = (*[0]byte)(C.step_tramp)
-		finalfn = (*[0]byte)(C.final_tramp)
+		stepfn = (*[0]byte)(C.c_step_tramp)
+		finalfn = (*[0]byte)(C.c_final_tramp)
 	} else {
-		funcfn = (*[0]byte)(C.func_tramp)
+		funcfn = (*[0]byte)(C.c_func_tramp)
 	}
 
 	res := C.go_sqlite3_create_function_v2(
@@ -197,8 +193,8 @@ func getxfuncs(ctx *C.sqlite3_context) *xfunc {
 	return x
 }
 
-//export func_tramp
-func func_tramp(ctx *C.sqlite3_context, n C.int, valarray **C.sqlite3_value) {
+//export go_func_tramp
+func go_func_tramp(ctx *C.sqlite3_context, n C.int, valarray **C.sqlite3_value) {
 	x := getxfuncs(ctx)
 	var vals []Value
 	if n > 0 {
@@ -207,8 +203,8 @@ func func_tramp(ctx *C.sqlite3_context, n C.int, valarray **C.sqlite3_value) {
 	x.xFunc(Context{ptr: ctx}, vals...)
 }
 
-//export step_tramp
-func step_tramp(ctx *C.sqlite3_context, n C.int, valarray **C.sqlite3_value) {
+//export go_step_tramp
+func go_step_tramp(ctx *C.sqlite3_context, n C.int, valarray **C.sqlite3_value) {
 	x := getxfuncs(ctx)
 	var vals []Value
 	if n > 0 {
@@ -217,8 +213,8 @@ func step_tramp(ctx *C.sqlite3_context, n C.int, valarray **C.sqlite3_value) {
 	x.xStep(Context{ptr: ctx}, vals...)
 }
 
-//export final_tramp
-func final_tramp(ctx *C.sqlite3_context) {
+//export go_final_tramp
+func go_final_tramp(ctx *C.sqlite3_context) {
 	x := getxfuncs(ctx)
 	x.xFinal(Context{ptr: ctx})
 }

--- a/session.go
+++ b/session.go
@@ -19,9 +19,6 @@ package sqlite
 // #include <sqlite3.h>
 // #include "wrappers.h"
 //
-// extern int go_strm_w_tramp(uintptr_t, char*, int);
-// extern int go_strm_r_tramp(uintptr_t, char*, int*);
-//
 // static int go_sqlite3session_changeset_strm(
 //   sqlite3_session *pSession,
 //   int (*xOutput)(void *pOut, const void *pData, int nData),

--- a/sqlite.go
+++ b/sqlite.go
@@ -609,7 +609,7 @@ func (stmt *Stmt) ClearBindings() error {
 //
 // https://www.sqlite.org/c3ref/step.html
 //
-// # Shared cache
+// Shared cache
 //
 // As the sqlite package enables shared cache mode by default
 // and multiple writers are common in multi-threaded programs,
@@ -985,11 +985,11 @@ func (stmt *Stmt) columnBytes(col int) []byte {
 
 // ColumnType are codes for each of the SQLite fundamental datatypes:
 //
-//	64-bit signed integer
-//	64-bit IEEE floating point number
-//	string
-//	BLOB
-//	NULL
+//   64-bit signed integer
+//   64-bit IEEE floating point number
+//   string
+//   BLOB
+//   NULL
 //
 // https://www.sqlite.org/c3ref/c_blob.html
 type ColumnType int
@@ -1022,11 +1022,11 @@ func (t ColumnType) String() string {
 // ColumnType returns the datatype code for the initial data
 // type of the result column. The returned value is one of:
 //
-//	SQLITE_INTEGER
-//	SQLITE_FLOAT
-//	SQLITE_TEXT
-//	SQLITE_BLOB
-//	SQLITE_NULL
+//   SQLITE_INTEGER
+//   SQLITE_FLOAT
+//   SQLITE_TEXT
+//   SQLITE_BLOB
+//   SQLITE_NULL
 //
 // Column indices start at 0.
 //

--- a/sqlite.go
+++ b/sqlite.go
@@ -52,7 +52,6 @@ package sqlite
 //	return sqlite3_bind_blob(stmt, col, p, n, SQLITE_TRANSIENT);
 // }
 //
-// extern void c_log_fn(void*, int, char*);
 // static void enable_logging() {
 //	sqlite3_config(SQLITE_CONFIG_LOG, c_log_fn, NULL);
 // }

--- a/sqlite.go
+++ b/sqlite.go
@@ -52,9 +52,9 @@ package sqlite
 //	return sqlite3_bind_blob(stmt, col, p, n, SQLITE_TRANSIENT);
 // }
 //
-// extern void log_fn(void* pArg, int code, char* msg);
+// extern void c_log_fn(void*, int, char*);
 // static void enable_logging() {
-//	sqlite3_config(SQLITE_CONFIG_LOG, log_fn, NULL);
+//	sqlite3_config(SQLITE_CONFIG_LOG, c_log_fn, NULL);
 // }
 //
 // static int db_config_onoff(sqlite3* db, int op, int onoff) {
@@ -169,7 +169,6 @@ func openConn(path string, flags ...OpenFlags) (*Conn, error) {
 			return nil, err
 		}
 	}
-
 
 	return conn, nil
 }
@@ -611,7 +610,7 @@ func (stmt *Stmt) ClearBindings() error {
 //
 // https://www.sqlite.org/c3ref/step.html
 //
-// Shared cache
+// # Shared cache
 //
 // As the sqlite package enables shared cache mode by default
 // and multiple writers are common in multi-threaded programs,
@@ -987,11 +986,11 @@ func (stmt *Stmt) columnBytes(col int) []byte {
 
 // ColumnType are codes for each of the SQLite fundamental datatypes:
 //
-//   64-bit signed integer
-//   64-bit IEEE floating point number
-//   string
-//   BLOB
-//   NULL
+//	64-bit signed integer
+//	64-bit IEEE floating point number
+//	string
+//	BLOB
+//	NULL
 //
 // https://www.sqlite.org/c3ref/c_blob.html
 type ColumnType int
@@ -1024,11 +1023,11 @@ func (t ColumnType) String() string {
 // ColumnType returns the datatype code for the initial data
 // type of the result column. The returned value is one of:
 //
-//   SQLITE_INTEGER
-//   SQLITE_FLOAT
-//   SQLITE_TEXT
-//   SQLITE_BLOB
-//   SQLITE_NULL
+//	SQLITE_INTEGER
+//	SQLITE_FLOAT
+//	SQLITE_TEXT
+//	SQLITE_BLOB
+//	SQLITE_NULL
 //
 // Column indices start at 0.
 //
@@ -1224,8 +1223,8 @@ func sqliteInitFn() {
 	}
 }
 
-//export log_fn
-func log_fn(_ unsafe.Pointer, code C.int, msg *C.char) {
+//export go_log_fn
+func go_log_fn(_ unsafe.Pointer, code C.int, msg *C.char) {
 	var msgBytes []byte
 	if msg != nil {
 		str := C.GoString(msg) // TODO: do not copy msg.

--- a/wrappers.c
+++ b/wrappers.c
@@ -42,6 +42,21 @@ int c_xapply_filter_tramp(void* pCtx, const char* zTab) {
         return go_xapply_filter_tramp((uintptr_t)pCtx, (char*)zTab);
 }
 
+extern void go_func_tramp(sqlite3_context*, int, sqlite3_value**);
+void c_func_tramp(sqlite3_context* ctx, int n, sqlite3_value** valarray) {
+        return go_func_tramp(ctx, n, valarray);
+}
+
+extern void go_step_tramp(sqlite3_context*, int, sqlite3_value**);
+void c_step_tramp(sqlite3_context* ctx, int n, sqlite3_value** valarray) {
+        return go_step_tramp(ctx, n, valarray);
+}
+
+extern void go_final_tramp(sqlite3_context*);
+void c_final_tramp(sqlite3_context* ctx) {
+        return go_final_tramp(ctx);
+}
+
 extern void go_destroy_tramp(uintptr_t);
 void c_destroy_tramp(void* ptr) {
         return go_destroy_tramp((uintptr_t)ptr);

--- a/wrappers.c
+++ b/wrappers.c
@@ -47,3 +47,12 @@ void c_destroy_tramp(void* ptr) {
         return go_destroy_tramp((uintptr_t)ptr);
 }
 
+extern int go_sqlite_auth_tramp(uintptr_t, int, char*, char*, char*, char*);
+int c_auth_tramp(void *userData, int action, const char* arg1, const char* arg2, const char* db, const char* trigger) {
+        return go_sqlite_auth_tramp((uintptr_t)userData, action, (char*)arg1, (char*)arg2, (char*)db, (char*)trigger);
+}
+
+extern void go_log_fn(void*, int, char*);
+void c_log_fn(void* pArg, int code, char* msg) {
+        return go_log_fn(pArg, code, msg);
+}

--- a/wrappers.h
+++ b/wrappers.h
@@ -26,6 +26,12 @@ int c_strm_r_tramp(void*, const void*, int*);
 int c_xapply_conflict_tramp(void*, int, sqlite3_changeset_iter*);
 int c_xapply_filter_tramp(void*, const char*);
 
+void c_log_fn(void*, int, char*);
+int c_auth_tramp(void*, int, const char*, const char*, const char*, const char*);
+
+void c_func_tramp(sqlite3_context*, int, sqlite3_value**);
+void c_step_tramp(sqlite3_context*, int, sqlite3_value**);
+void c_final_tramp(sqlite3_context*);
 void c_destroy_tramp(void*);
 
 #endif // WRAPPERS_H


### PR DESCRIPTION
The current source fails to build with clang on windows due to forward declarations.

It appears that cgo code within a go file shouldn't contain a forward declaration to a cgo exported function from within the same file.

This manifests as either a warning or an error on clang+windows due to dllexport. There is an open task on the golang repo to better document this: https://github.com/golang/go/issues/49721


Here's what happens if you try and build this package using clang (or zig cc) on windows.
```
In file included from _cgo_export.c:4:
cgo-gcc-export-header-prolog:49:34: error: redeclaration of 'go_sqlite_auth_tramp' cannot add 'dllexport' attribute
   49 | extern __declspec(dllexport) int go_sqlite_auth_tramp(GoUintptr id, int action, char* cArg1, char* cArg2, char* cDB, char* cTrigger);
      |                                  ^
auth.go:5:13: note: previous declaration is here
    5 |  extern int go_sqlite_auth_tramp(uintptr_t, int, char*, char*, char*, char*);
      |             ^
cgo-gcc-export-header-prolog:50:35: warning: redeclaration of 'func_tramp' should not add 'dllexport' attribute [-Wdll-attribute-on-redeclaration]
   50 | extern __declspec(dllexport) void func_tramp(sqlite3_context* ctx, int n, sqlite3_value** valarray);
      |                                   ^
func.go:22:14: note: previous declaration is here
   22 |  extern void func_tramp(sqlite3_context*, int, sqlite3_value**);
      |              ^
cgo-gcc-export-header-prolog:51:35: warning: redeclaration of 'step_tramp' should not add 'dllexport' attribute [-Wdll-attribute-on-redeclaration]
   51 | extern __declspec(dllexport) void step_tramp(sqlite3_context* ctx, int n, sqlite3_value** valarray);
      |                                   ^
func.go:23:14: note: previous declaration is here
   23 |  extern void step_tramp(sqlite3_context*, int, sqlite3_value**);
      |              ^
cgo-gcc-export-header-prolog:52:35: warning: redeclaration of 'final_tramp' should not add 'dllexport' attribute [-Wdll-attribute-on-redeclaration]
   52 | extern __declspec(dllexport) void final_tramp(sqlite3_context* ctx);
      |                                   ^
func.go:24:14: note: previous declaration is here
   24 |  extern void final_tramp(sqlite3_context*);
      |              ^
cgo-gcc-export-header-prolog:54:34: warning: redeclaration of 'go_strm_w_tramp' should not add 'dllexport' attribute [-Wdll-attribute-on-redeclaration]
   54 | extern __declspec(dllexport) int go_strm_w_tramp(GoUintptr pOut, char* pData, int n);
      |                                  ^
session.go:22:13: note: previous declaration is here
   22 |  extern int go_strm_w_tramp(uintptr_t, char*, int);
      |             ^
cgo-gcc-export-header-prolog:55:34: warning: redeclaration of 'go_strm_r_tramp' should not add 'dllexport' attribute [-Wdll-attribute-on-redeclaration]
   55 | extern __declspec(dllexport) int go_strm_r_tramp(GoUintptr pIn, char* pData, int* pnData);
      |                                  ^
session.go:23:13: note: previous declaration is here
   23 |  extern int go_strm_r_tramp(uintptr_t, char*, int*);
      |             ^
cgo-gcc-export-header-prolog:58:35: error: redeclaration of 'log_fn' cannot add 'dllexport' attribute
   58 | extern __declspec(dllexport) void log_fn(void* _, int code, char* msg);
      |                                   ^
sqlite.go:55:14: note: previous declaration is here
   55 |  extern void log_fn(void* pArg, int code, char* msg);
      |              ^
5 warnings and 2 errors generated.
```

This PR:
1. Moves the offending c trampolines into the wrappers.c/h files, which addresses this issue since there are longer forward declarations in the Go code. There is precedent for this, since it looks like this was already done for sometrampolines.
2. Fixes a typo in the readme to use the correct `CGO_LDFLAGS` env var for the windows linker

Should fix the root issue in https://github.com/crawshaw/sqlite/issues/137